### PR TITLE
Handle map == null case in Reply

### DIFF
--- a/SpeakUp/Talk.cs
+++ b/SpeakUp/Talk.cs
@@ -49,6 +49,7 @@ namespace SpeakUp
             if (SpeakUpSettings.sameRegionRestriction)
             {
                 Map map = Initiator.Map;
+                if (map == null) return;
                 if (RegionAndRoomQuery.DistirctAtFast(Initiator.Position, map, RegionType.Normal) != RegionAndRoomQuery.DistirctAtFast(Recipient.Position, map, RegionType.Normal) && 
                     Initiator.Position.DistanceTo(Recipient.Position) >= 14f) return;
             }


### PR DESCRIPTION
The Initiator's map can be null if they no longer exist on a map. In that case they must not be in a region we care about. We run into this issue when we try to access the recipient's logs. In that case the logs appear permanently empty and our error log gets spammed with the below.

Fixes:
```
[SpeakUp] Error processing extra rules: Object reference not set to an instance of an object
Initator: SomePawn, recipient: SomeOtherPawn.
Zero rules processed.
Exception filling tab RimWorld.ITab_Pawn_Log: System.NullReferenceException: Object reference not set to an instance of an object
[Ref FB1BFA27]
  at Verse.RegionAndRoomQuery.DistirctAtFast (Verse.IntVec3 c, Verse.Map map, Verse.RegionType allowedRegionTypes) [0x00000] in <24d25868955f4df08b02c73b55f389fe>:0 
  at SpeakUp.Talk.Reply (System.String tag) [0x00020] in <e7d1164b603643f8a50c693bb13965a0>:0 
SpeakUp.Talk..ctor(String tag)
...
```